### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,3 +420,8 @@ Or explore style variations with prompt modifiers:
 
 Made with ❤️ by Yaroslav Boiko
 
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/awkoy-replicate-flux-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/awkoy-replicate-flux-mcp).